### PR TITLE
chore: tsconfig 설정을 Vue 3에 맞게 개선

### DIFF
--- a/services/frontend/tsconfig.json
+++ b/services/frontend/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
@@ -7,6 +7,10 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "jsx": "preserve",
+    "jsxImportSource": "vue"
   }
 } 


### PR DESCRIPTION
## 개요

tsconfig 설정을 Vue 3에 맞게 개선


## 주요 변경사항

- @vue/tsconfig 대신 @tsconfig/node18를 기본 설정으로 사용
- Vue 3 관련 컴파일러 옵션 추가:
  - module: ESNext 모듈 시스템 사용
  - moduleResolution: Node.js 스타일의 모듈 해석
  - jsx: Vue 템플릿 지원을 위한 JSX 보존
  - jsxImportSource: Vue JSX 지원